### PR TITLE
Remove explicit join on collect cancel

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/FlowTurbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/FlowTurbine.kt
@@ -198,8 +198,6 @@ private class ChannelBasedFlowTurbine<T>(
 
   override suspend fun cancel() {
     collectJob.cancel()
-    // Non-JVM platforms may not perform cancellation synchronously so force its handling.
-    collectJob.join()
   }
 
   override suspend fun cancelAndIgnoreRemainingEvents(): Nothing {


### PR DESCRIPTION
This was needed before we used an undispatched coroutine, but after the switch is redundant.