### PR TITLE
Add support for Javascript IR backend

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,8 @@
 # Change Log
 
 ## [Unreleased]
-
+### Added
+- Support Javascript IR backend
 
 ## [0.2.0] - 2020-08-17
 ### Changed

--- a/gradle.properties
+++ b/gradle.properties
@@ -20,3 +20,5 @@ POM_LICENCE_DIST=repo
 POM_DEVELOPER_ID=cashapp
 POM_DEVELOPER_NAME=CashApp
 POM_DEVELOPER_URL=https://github.com/cashapp/
+
+kotlin.js.compiler=both


### PR DESCRIPTION
Tested via `./gradlew build publishToMavenLocal` and was able to consume in a test project which also used `kotlin.js.compiler=both` and was previously failing to resolve js targets.