### PR TITLE
add sample compile configuration using kotlin DSL

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,8 @@ minimal and would likely only require a version bump.
 Instead of sprinkling the experimental annotations or `@OptIn` all over your tests, opt-in at the
 compiler level.
 
+### Groovy DSL
+
 ```groovy
 compileTestKotlin {
   kotlinOptions {
@@ -210,6 +212,19 @@ compileTestKotlin {
         '-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi',
     ]
   }
+}
+```
+
+### Kotlin DSL
+
+```kotlin
+tasks.compileTestKotlin {
+    kotlinOptions {
+        freeCompilerArgs += listOf(
+                "-Xopt-in=kotlin.time.ExperimentalTime",
+                "-Xopt-in=kotlinx.coroutines.ExperimentalCoroutinesApi"
+        )
+    }
 }
 ```
 


### PR DESCRIPTION
this add a configuration sample to the documentation that shows how the experimental annotations can be enabled using the gradle kotlin DSL