### PR TITLE
Do not run build workflow on tags

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -1,6 +1,12 @@
 name: build
 
-on: [push, pull_request]
+on:
+  pull_request: {}
+  push:
+    branches:
+      - '*'
+    tags-ignore:
+      - '*'
 
 env:
   GRADLE_OPTS: "-Dorg.gradle.jvmargs=-Xmx4g -Dorg.gradle.daemon=false -Dkotlin.incremental=false"


### PR DESCRIPTION
Running the `build` task fails as it tries to sign the artifacts (since they're a non-snapshot version). We could add the signing key to the action, but there's no point in running this workflow at all since the release workflow is doing all this work.