### PR TITLE
Add cancel which returns unconsumed events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,9 @@
 # Change Log
 
 ## [Unreleased]
-
+### Added
+- `cancelAndConsumeRemainingEvents()` cancels the `Flow` and returns any unconsumed events which were already received.
+- `expectEvent()` waits for an event (item, complete, or error) and returns it as a sealed type `Event`.
 
 ## [0.2.1]
 ### Added


### PR DESCRIPTION
Since this requires exposing the Event type, add an `expectEvent()` function as well.

Closes #17.