### PR TITLE
Add a function for receiving the most recent emitted item

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,25 @@ flowOf("one", "two").test {
 }
 ```
 
+Additionally, we can receive the most recent emitted item and ignore the previous ones.
+
+```kotlin
+flowOf("one", "two", "three")
+  .map {
+    delay(100)
+    it
+  }
+  .test {
+    // 0 - 100ms -> no emission yet
+    // 100ms - 200ms -> "one" is emitted
+    // 200ms - 300ms -> "two" is emitted
+    // 300ms - 400ms -> "three" is emitted
+    delay(250)
+    assertEquals("two", expectMostRecentItem())
+    cancelAndIgnoreRemainingEvents()
+  }
+```
+
 #### Consuming Errors
 
 Unlike `collect`, a flow which causes an exception will still be exposed as an event that you

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTurbineTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTurbineTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.channels.Channel
@@ -29,6 +30,7 @@ import kotlinx.coroutines.flow.emitAll
 import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOf
+import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
@@ -385,5 +387,68 @@ class FlowTurbineTest {
 
     channel.send("two")
     assertEquals(3, position)
+  }
+
+  @Test fun exceptionsPropagateWhenExpectMostRecentItem() = suspendTest {
+    // Use a custom subtype to prevent coroutines from breaking referential equality.
+    val expected = object : RuntimeException("hello") {}
+
+    val actual = assertThrows<RuntimeException> {
+      flow {
+        emit(1)
+        emit(2)
+        emit(3)
+        throw expected
+      }.test {
+        expectMostRecentItem()
+      }
+    }
+    assertSame(expected, actual)
+  }
+
+  @Test fun expectMostRecentItemButNoItemWasFoundThrows() = suspendTest {
+    val actual = assertThrows<AssertionError> {
+      emptyFlow<Any>().test {
+        expectMostRecentItem()
+      }
+    }
+    assertEquals("No item was found", actual.message)
+  }
+
+  @Test fun expectMostRecentItem() = suspendTest {
+    val onTwoSent = CompletableDeferred<Unit>()
+    val onTwoContinue = CompletableDeferred<Unit>()
+    val onCompleteSent = CompletableDeferred<Unit>()
+    val onCompleteContinue = CompletableDeferred<Unit>()
+
+    flowOf(1, 2, 3, 4, 5)
+      .map {
+        if (it == 3) {
+          onTwoSent.complete(Unit)
+          onTwoContinue.await()
+        }
+        it
+      }
+      .onCompletion {
+        onCompleteSent.complete(Unit)
+        onCompleteContinue.await()
+      }
+      .test {
+        onTwoSent.await()
+        assertEquals(2, expectMostRecentItem())
+        onTwoContinue.complete(Unit)
+
+        onCompleteSent.await()
+        assertEquals(5, expectMostRecentItem())
+        onCompleteContinue.complete(Unit)
+        expectComplete()
+      }
+  }
+
+  @Test fun assertNullValuesWithExpectMostRecentItem() = suspendTest {
+    flowOf(1, 2, null).test {
+      assertEquals(null, expectMostRecentItem())
+      cancelAndIgnoreRemainingEvents()
+    }
   }
 }


### PR DESCRIPTION
Sometimes we may need to assert only the final item, so it would be helpful to have a function that returns it (if exists). With this PR, we return the last item that is emitted from a `Flow`. If the `Flow` throws an exception, then the exception will be propagated. If no item is emitted, then an `AssertionError` will be thrown.