### PR TITLE
Mark the `ignoreRemainingEventsException` as SharedImmutable

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -84,6 +84,22 @@ kotlin {
       useExperimentalAnnotation('kotlinx.coroutines.ExperimentalCoroutinesApi')
     }
   }
+
+  // Add a test binary and execution for native targets which runs on a background thread.
+  targets.withType(org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests).all {
+    binaries {
+      test('background', [org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG]) {
+        freeCompilerArgs += [
+          "-trw"
+        ]
+      }
+    }
+    testRuns {
+      background {
+        setExecutionSourceFrom(binaries.getByName("backgroundDebugTest"))
+      }
+    }
+  }
 }
 
 apply plugin: 'com.diffplug.spotless'

--- a/src/commonMain/kotlin/app/cash/turbine/FlowTurbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/FlowTurbine.kt
@@ -15,6 +15,7 @@
  */
 package app.cash.turbine
 
+import kotlin.native.concurrent.SharedImmutable
 import kotlin.time.Duration
 import kotlin.time.ExperimentalTime
 import kotlinx.coroutines.CancellationException
@@ -177,6 +178,7 @@ public interface FlowTurbine<T> {
   public suspend fun expectError(): Throwable
 }
 
+@SharedImmutable
 private val ignoreRemainingEventsException = CancellationException("Ignore remaining events")
 
 public sealed class Event<out T> {


### PR DESCRIPTION
…can be used from different threads on iOS.

Before, my tests were failing with:

```
kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread
kotlin.native.IncorrectDereferenceException: Trying to access top level value not marked as @ThreadLocal or @SharedImmutable from non-main thread
	at kotlin.Throwable#<init>(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/Throwable.kt:23)
	at kotlin.Exception#<init>(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/Exceptions.kt:23)
	at kotlin.RuntimeException#<init>(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/Exceptions.kt:34)
	at kotlin.native.IncorrectDereferenceException#<init>(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/native/Runtime.kt:31)
	at <global>.ThrowIncorrectDereferenceException(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/native/internal/RuntimeUtils.kt:103)
	at <global>.CheckGlobalsAccessible(Unknown Source)
	at app.cash.turbine.<get-ignoreRemainingEventsException>#internal(/Users/runner/work/turbine/turbine/src/commonMain/kotlin/app/cash/turbine/FlowTurbine.kt:181)
	at app.cash.turbine.$test$lambda-1COROUTINE$1.invokeSuspend#internal(/Users/runner/work/turbine/turbine/src/commonMain/kotlin/app/cash/turbine/FlowTurbine.kt:91)
	at kotlin.coroutines.native.internal.BaseContinuationImpl#resumeWith(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/coroutines/ContinuationImpl.kt:30)
	at kotlinx.coroutines.internal.ShareableContinuation#resumeWith(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/internal/Sharing.kt:185)
	at kotlinx.coroutines.internal.ScopeCoroutine#afterResume(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/common/src/internal/Scopes.kt:33)
	at kotlinx.coroutines.AbstractCoroutine#resumeWith(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/common/src/AbstractCoroutine.kt:113)
	at kotlin.coroutines.native.internal.BaseContinuationImpl#resumeWith(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/coroutines/ContinuationImpl.kt:43)
	at kotlinx.coroutines.DispatchedTask#run(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/common/src/internal/DispatchedTask.kt:103)
	at kotlinx.coroutines.EventLoopImplBase#processNextEvent(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/common/src/EventLoop.common.kt:277)
	at kotlinx.coroutines#runEventLoop(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Builders.kt:80)
	at kotlinx.coroutines.WorkerCoroutineDispatcherImpl.start$lambda-0#internal(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Workers.kt:49)
	at kotlinx.coroutines.WorkerCoroutineDispatcherImpl.$start$lambda-0$FUNCTION_REFERENCE$35.invoke#internal(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Workers.kt:47)
	at kotlinx.coroutines.WorkerCoroutineDispatcherImpl.$start$lambda-0$FUNCTION_REFERENCE$35.$<bridge-UNN>invoke(/opt/buildAgent/work/44ec6e850d5c63f0/kotlinx-coroutines-core/native/src/Workers.kt:47)
	at <global>.WorkerLaunchpad(/Users/teamcity3/buildAgent/work/94570f55b55e6619/runtime/src/main/kotlin/kotlin/native/concurrent/Internal.kt:70)
	at <global>._ZN6Worker19processQueueElementEb(Unknown Source)
	at <global>._ZN12_GLOBAL__N_113workerRoutineEPv(Unknown Source)
	at <global>._pthread_start(Unknown Source)
	at <global>.thread_start(Unknown Source)
```