### PR TITLE
Move experimental time APIs outside the critical path

### DIFF
--- a/README.md
+++ b/README.md
@@ -209,7 +209,7 @@ channelFlow {
 
 #### Hot Flows
 
-Emissions to hot flows that don't have active consumers are dropped. It's important to call `test` 
+Emissions to hot flows that don't have active consumers are dropped. It's important to call `test`
 (and therefore have an active collector) on a flow _before_ emissions to a flow are made. For example:
 
 ```kotlin
@@ -219,9 +219,9 @@ mutableSharedFlow.test {
   assertEquals(awaitItem(), 1)
   cancelAndConsumeRemainingEvents()
 }
-``` 
+```
 
-will fail with a timeout exception. 
+will fail with a timeout exception.
 
 ```
 kotlinx.coroutines.TimeoutCancellationException: Timed out waiting for 1000 ms
@@ -231,7 +231,7 @@ kotlinx.coroutines.TimeoutCancellationException: Timed out waiting for 1000 ms
 	at app.cash.turbine.ChannelBasedFlowTurbine.awaitItem(FlowTurbine.kt:243)
 ```
 
-Proper usage of Turbine with hot flows looks like the following. 
+Proper usage of Turbine with hot flows looks like the following.
 
 ```kotlin
 val mutableSharedFlow = MutableSharedFlow<Int>(replay = 0)
@@ -249,65 +249,6 @@ The hot flow types Kotlin currently provide are:
 * `SharedFlow`
 * Channels converted to flow with `Channel.consumeAsFlow`
 
-## Experimental API Usage
-
-Turbine uses Kotlin experimental APIs:
-
- * `Duration` is used to declare the event timeout.
-
-Since the library targets test code, the impact and risk of any breaking changes to these APIs are
-minimal and would likely only require a version bump.
-
-Instead of sprinkling the experimental annotations or `@OptIn` all over your tests, opt-in at the
-compiler level.
-
-### Groovy DSL
-
-```groovy
-compileTestKotlin {
-  kotlinOptions {
-    freeCompilerArgs += [
-        '-Xopt-in=kotlin.time.ExperimentalTime',
-    ]
-  }
-}
-```
-
-### Kotlin DSL
-
-```kotlin
-tasks.compileTestKotlin {
-  kotlinOptions {
-    freeCompilerArgs += listOf(
-        "-Xopt-in=kotlin.time.ExperimentalTime",
-    )
-  }
-}
-```
-
-For multiplatform projects:
-
-### Groovy DSL
-
-```groovy
-kotlin {
-  sourceSets.matching { it.name.endsWith("Test") }.all {
-    it.languageSettings {
-      optIn('kotlin.time.ExperimentalTime')
-    }
-  }
-}
-```
-
-### Kotlin DSL
-
-```kotlin
-kotlin.sourceSets.matching {
-  it.name.endsWith("Test")
-}.configureEach {
-  languageSettings.optIn("kotlin.time.ExperimentalTime")
-}
-```
 
 # License
 

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTurbineTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTurbineTest.kt
@@ -20,6 +20,7 @@ import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertSame
 import kotlin.test.assertTrue
+import kotlin.time.Duration
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers.Unconfined
@@ -36,6 +37,20 @@ import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
 
 class FlowTurbineTest {
+  @Test fun timeoutLong() = suspendTest {
+    neverFlow().test(timeoutMs = 1_234L) {
+      assertEquals(1_234L, timeoutMs)
+      assertEquals(Duration.milliseconds(1_234L), timeout)
+    }
+  }
+
+  @Test fun timeoutDuration() = suspendTest {
+    neverFlow().test(timeout = Duration.milliseconds(1_234L)) {
+      assertEquals(1_234L, timeoutMs)
+      assertEquals(Duration.milliseconds(1_234L), timeout)
+    }
+  }
+
   @Test fun exceptionsPropagate() = suspendTest {
     // Use a custom subtype to prevent coroutines from breaking referential equality.
     val expected = object : RuntimeException("hello") {}

--- a/src/jvmTest/kotlin/app/cash/turbine/FlowTurbineJvmTest.kt
+++ b/src/jvmTest/kotlin/app/cash/turbine/FlowTurbineJvmTest.kt
@@ -43,7 +43,26 @@ class FlowTurbineJvmTest {
     assertEquals("Timed out waiting for 1000 ms", actual.message)
   }
 
-  @Test fun timeoutEnforcedCustomValue() = jvmSuspendTest {
+  @Test fun timeoutEnforcedCustomLong() = jvmSuspendTest {
+    val subject = async {
+      neverFlow().test(timeoutMs = 10_000) {
+        awaitComplete()
+      }
+    }
+
+    advanceTimeBy(Duration.milliseconds(9999))
+    assertTrue(subject.isActive)
+
+    advanceTimeBy(Duration.milliseconds(1))
+    assertFalse(subject.isActive)
+
+    val actual = assertThrows<TimeoutCancellationException> {
+      subject.await()
+    }
+    assertEquals("Timed out waiting for 10000 ms", actual.message)
+  }
+
+  @Test fun timeoutEnforcedCustomDuration() = jvmSuspendTest {
     val subject = async {
       neverFlow().test(timeout = Duration.seconds(10)) {
         awaitComplete()
@@ -64,7 +83,7 @@ class FlowTurbineJvmTest {
 
   @Test fun timeoutCanBeZero() = jvmSuspendTest {
     val subject = async {
-      neverFlow().test(timeout = Duration.ZERO) {
+      neverFlow().test(timeoutMs = 0) {
         awaitComplete()
       }
     }


### PR DESCRIPTION
This avoids Kotlin and coroutine version mismatch problems that can be hard to diagnose.

Closes #68 (kinda). Closes #67 (also kinda). Side-stepping these problems completely.