### PR TITLE
Kotlin 1.6 support

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -13,11 +13,7 @@ env:
 
 jobs:
   build:
-    strategy:
-      matrix:
-        os: [macOS-latest, windows-latest]
-
-    runs-on: ${{matrix.os}}
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2
@@ -30,19 +26,13 @@ jobs:
       - run: ./gradlew build
 
       - run: ./gradlew publish
-        if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/turbine' && matrix.os == 'macOS-latest' }}
-        env:
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-
-      - run: ./gradlew publishMingwX64PublicationToMavenRepository
-        if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/turbine' && matrix.os == 'windows-latest' }}
+        if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/turbine' }}
         env:
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
           ORG_GRADLE_PROJECT_SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
 
       - name: Deploy docs to website
-        if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/turbine' && matrix.os == 'macOS-latest' }}
+        if: ${{ github.ref == 'refs/heads/trunk' && github.repository == 'cashapp/turbine' }}
         uses: JamesIves/github-pages-deploy-action@releases/v3
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -10,11 +10,7 @@ env:
 
 jobs:
   publish:
-    strategy:
-      matrix:
-        os: [macOS-latest, windows-latest]
-
-    runs-on: ${{matrix.os}}
+    runs-on: macos-11
 
     steps:
       - uses: actions/checkout@v2
@@ -30,24 +26,6 @@ jobs:
           SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
           ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
         run: ./gradlew build publish
-        if: matrix.os == 'macOS-latest'
-
-      - name: Build and publish artifacts
-        env:
-          SONATYPE_NEXUS_USERNAME: ${{ secrets.SONATYPE_NEXUS_USERNAME }}
-          SONATYPE_NEXUS_PASSWORD: ${{ secrets.SONATYPE_NEXUS_PASSWORD }}
-          ORG_GRADLE_PROJECT_signingKey: ${{ secrets.ARTIFACT_SIGNING_PRIVATE_KEY }}
-        run: ./gradlew build publishMingwX64PublicationToMavenRepository
-        if: matrix.os == 'windows-latest'
-
-  github_release:
-    runs-on: ubuntu-latest
-
-    needs:
-      - publish
-
-    steps:
-      - uses: actions/checkout@v2
 
       - name: Extract release notes
         id: release_notes
@@ -57,7 +35,6 @@ jobs:
         uses: softprops/action-gh-release@v1
         with:
           body: ${{ steps.release_notes.outputs.release_notes }}
-          files: build/libs/*
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.5.31'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.6.0'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.15.1'
     classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
     classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.5.30'
@@ -87,7 +87,6 @@ kotlin {
 
   sourceSets.matching { it.name.endsWith("Test") }.all {
     it.languageSettings {
-      optIn('kotlin.time.ExperimentalTime')
       optIn('kotlinx.coroutines.DelicateCoroutinesApi')
       optIn('kotlinx.coroutines.ExperimentalCoroutinesApi')
     }

--- a/src/jvmTest/kotlin/app/cash/turbine/FlowTurbineJvmTest.kt
+++ b/src/jvmTest/kotlin/app/cash/turbine/FlowTurbineJvmTest.kt
@@ -18,7 +18,9 @@ package app.cash.turbine
 import kotlin.test.assertEquals
 import kotlin.test.assertFalse
 import kotlin.test.assertTrue
-import kotlin.time.Duration
+import kotlin.time.Duration.Companion.days
+import kotlin.time.Duration.Companion.milliseconds
+import kotlin.time.Duration.Companion.seconds
 import kotlinx.coroutines.TimeoutCancellationException
 import kotlinx.coroutines.async
 import org.junit.Test
@@ -31,10 +33,10 @@ class FlowTurbineJvmTest {
       }
     }
 
-    advanceTimeBy(Duration.milliseconds(999))
+    advanceTimeBy(999.milliseconds)
     assertTrue(subject.isActive)
 
-    advanceTimeBy(Duration.milliseconds(1))
+    advanceTimeBy(1.milliseconds)
     assertFalse(subject.isActive)
 
     val actual = assertThrows<TimeoutCancellationException> {
@@ -50,10 +52,10 @@ class FlowTurbineJvmTest {
       }
     }
 
-    advanceTimeBy(Duration.milliseconds(9999))
+    advanceTimeBy(9999.milliseconds)
     assertTrue(subject.isActive)
 
-    advanceTimeBy(Duration.milliseconds(1))
+    advanceTimeBy(1.milliseconds)
     assertFalse(subject.isActive)
 
     val actual = assertThrows<TimeoutCancellationException> {
@@ -64,15 +66,15 @@ class FlowTurbineJvmTest {
 
   @Test fun timeoutEnforcedCustomDuration() = jvmSuspendTest {
     val subject = async {
-      neverFlow().test(timeout = Duration.seconds(10)) {
+      neverFlow().test(timeout = 10.seconds) {
         awaitComplete()
       }
     }
 
-    advanceTimeBy(Duration.milliseconds(9999))
+    advanceTimeBy(9999.milliseconds)
     assertTrue(subject.isActive)
 
-    advanceTimeBy(Duration.milliseconds(1))
+    advanceTimeBy(1.milliseconds)
     assertFalse(subject.isActive)
 
     val actual = assertThrows<TimeoutCancellationException> {
@@ -88,7 +90,7 @@ class FlowTurbineJvmTest {
       }
     }
 
-    advanceTimeBy(Duration.days(10))
+    advanceTimeBy(10.days)
     assertTrue(subject.isActive)
 
     subject.cancel()

--- a/src/jvmTest/kotlin/app/cash/turbine/jvmTestUtil.kt
+++ b/src/jvmTest/kotlin/app/cash/turbine/jvmTestUtil.kt
@@ -16,7 +16,9 @@
 package app.cash.turbine
 
 import kotlin.time.Duration
+import kotlin.time.Duration.Companion.milliseconds
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.runBlocking
 import kotlinx.coroutines.test.DelayController
@@ -36,6 +38,7 @@ fun jvmSuspendTest(body: suspend TestCoroutineScope.() -> Unit) {
   scope.cleanupTestCoroutines()
 }
 
+@ExperimentalCoroutinesApi
 fun DelayController.advanceTimeBy(duration: Duration): Duration {
-  return Duration.milliseconds(advanceTimeBy(duration.inWholeMilliseconds))
+  return advanceTimeBy(duration.inWholeMilliseconds).milliseconds
 }


### PR DESCRIPTION
Remove Windows workers as it can now be cross-compiled. Promote Duration back to main function as it is now stable.

Closes #75. We don't need to wait for kotlinx.coroutines because Kotlin/Native remains compatible.