### PR TITLE
Remove timeout

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -21,6 +21,6 @@ POM_DEVELOPER_ID=cashapp
 POM_DEVELOPER_NAME=CashApp
 POM_DEVELOPER_URL=https://github.com/cashapp/
 
-kotlin.js.compiler=ir
+kotlin.js.compiler=both
 
 kotlin.mpp.stability.nowarn=true


### PR DESCRIPTION
The runTest function enforces one on every platform.

This also restores legacy JS compilation, just because we can now.