### PR TITLE
Delete cancel method on hot flows doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -204,7 +204,6 @@ val mutableSharedFlow = MutableSharedFlow<Int>(replay = 0)
 mutableSharedFlow.emit(1)
 mutableSharedFlow.test {
   assertEquals(awaitItem(), 1)
-  cancelAndConsumeRemainingEvents()
 }
 ```
 ```
@@ -223,7 +222,6 @@ val mutableSharedFlow = MutableSharedFlow<Int>(replay = 0)
 mutableSharedFlow.test {
   mutableSharedFlow.emit(1)
   assertEquals(awaitItem(), 1)
-  cancelAndConsumeRemainingEvents()
 }
 ```
 


### PR DESCRIPTION
From the version [0.8.0](https://github.com/cashapp/turbine/releases/tag/0.8.0) of turbine, there is no more need to call a cancel method (`cancel`, `cancelAndIgnoreRemainingEvents` or `cancelAndConsumeRemainingEvents`), because the flow is automatically cancelled at the end of `test` lambda.

For this reason, this PR deletes the `cancelAndConsumeRemainingEvents` method from the `Hot flows` paragraph simplifying that part of documentation.