### PR TITLE
Add documentation to assert currentTime

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,25 @@ flowOf("one", "two", "three")
   }
 ```
 
+Delay between emissions can be asserted with `currentTime` when using `runTest`.
+
+```kotlin
+flowOf("one", "two", "three")
+  .map {
+    delay(100)
+    it
+  }
+  .test {
+    assertEquals("one", awaitItem())
+    assertEquals(100, currentTime)
+    assertEquals("two", awaitItem())
+    assertEquals(200, currentTime)
+    assertEquals("three", awaitItem())
+    awaitComplete()
+    assertEquals(300, currentTime)
+  }
+```
+
 ### Consuming Errors
 
 Unlike `collect`, a flow which causes an exception will still be exposed as an event that you


### PR DESCRIPTION
I think this is the only "correct" way to assert at which time an element has been emitted and when the Flow ends. 

The other solution would be less secure : 
```kotlin
flowOf("one", "two", "three")
  .map {
    delay(100)
    it
  }
  .test {
    advanceTimeBy(100) // or delay(100), whatever fits your needs
    runCurrent()
    assertEquals("one", expectMostRecentItem()) // <-- if .onStart { emit("one" } is used (or "one" is emitted twice), test wouldn't fail
    advanceTimeBy(100)
    runCurrent()
    assertEquals("two", expectMostRecentItem())
    advanceTimeBy(100)
    runCurrent()
    assertEquals("three", expectMostRecentItem())
    awaitComplete() // <-- mix between "await" and "expect"
    assertEquals(300, currentTime) // <-- mix between "advanceTimeBy" and "assert currentTime"
  }
```