### PR TITLE
Restore timeouts using virtual time

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -42,6 +42,8 @@ kotlin {
     commonMain {
       dependencies {
         api "org.jetbrains.kotlinx:kotlinx-coroutines-core:${versions.coroutines}"
+        implementation 'org.jetbrains.kotlin:kotlin-test'
+        implementation "org.jetbrains.kotlinx:kotlinx-coroutines-test:${versions.coroutines}"
       }
     }
     commonTest {

--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -110,7 +110,7 @@ internal class TurbineImpl<T>(
     override fun tryReceive(): ChannelResult<T> {
       val result = channel.tryReceive()
       val event = result.toEvent()
-      if (event is Event.Error || event is Event.Item) ignoreRemainingEvents = true
+      if (event is Event.Error || event is Event.Complete) ignoreRemainingEvents = true
 
       return result
     }

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
@@ -334,8 +334,10 @@ class FlowTest {
   }
 
   @Test fun expectCompleteButWasErrorThrows() = runTest {
-    emptyFlow<Nothing>().test {
-      awaitComplete()
+    assertFailsWith<AssertionError> {
+      flow<Nothing>{ throw RuntimeException() }.test {
+        awaitComplete()
+      }
     }
   }
 


### PR DESCRIPTION
Proposing this PR because timeouts are a critical part of the dev workflow for us. They happen all the time; `runTest`'s 60s wall clock time timeout is okay, but:

1. 60s is long. Too long to use for a situation that represents a bug that I might want to TDD on
2. No feedback is provided on the `await` call site that caused the issue.

Internally at Cash App, we've just been using `runBlocking` with wall clock time timeouts for this scenario. This meets a lot of our needs, but also has a couple of major drawbacks:

1. Even at 1s wall clock time, that's annoying.
2. 1s is way too long for the happy path. (e.g. I might want to assert that I send some event to a presenter, and nothing happens in response)

This PR is an attempt to restore timeouts with good support for virtual time on `runTest`. Two big changes from the old support:

1. All timeouts are wrapped in `AssertionError` with an appropriate error message.
2. The timeout duration itself is provided via a `CoroutineContext` element. This helps keep parameters from proliferating, and makes it easier to declare this once.

Very open to feedback.