### PR TITLE
Use Coroutines 1.6.4.

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ buildscript {
   }
 
   ext.versions = [
-    'coroutines': '1.6.1',
+    'coroutines': '1.6.4',
   ]
 }
 


### PR DESCRIPTION
+ I experience test failures when I upgrade the Gradle wrapper from 7.2 to 7.5.1 in my project. Therefore, I like to see if any issue comes up here already. See #141.
+ I also use Coroutines 1.6.4. Testing this in isolation here first.
+ Release notes: https://github.com/Kotlin/kotlinx.coroutines/releases