### PR TITLE
Remove public property indicating ignoring remaining events

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/ReceiveTurbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/ReceiveTurbine.kt
@@ -24,11 +24,6 @@ public interface ReceiveTurbine<T> {
   public fun asChannel(): ReceiveChannel<T>
 
   /**
-   * True if remaining events for this test channel have been ignored.
-   */
-  public val ignoreRemainingEvents: Boolean
-
-  /**
    * Cancel this [ReceiveTurbine].
    *
    * If it is backed by an underlying coroutine (e.g. the coroutine run

--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -142,9 +142,7 @@ internal class ChannelTurbine<T>(
   override fun takeError(): Throwable = channel.takeError()
 
   private var ignoreTerminalEvents = false
-
-  override var ignoreRemainingEvents: Boolean = false
-    private set
+  private var ignoreRemainingEvents = false
 
   override suspend fun cancelAndIgnoreRemainingEvents() {
     cancel()


### PR DESCRIPTION
No known reason for it to live in the public API.

Closes #131 