### PR TITLE
Fix bugs with trailing events after expectRecentItem within test blocks

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -100,7 +100,7 @@ internal class ChannelTurbine<T>(
     override fun tryReceive(): ChannelResult<T> {
       val result = channel.tryReceive()
       val event = result.toEvent()
-      if (event is Event.Error || event is Event.Item) ignoreRemainingEvents = true
+      if (event is Event.Error || event is Event.Complete) ignoreRemainingEvents = true
 
       return result
     }

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
@@ -25,6 +25,7 @@ import kotlin.test.assertTrue
 import kotlinx.coroutines.CompletableDeferred
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers.Unconfined
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.NonCancellable
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.RENDEZVOUS
@@ -345,6 +346,26 @@ class FlowTest {
     flow<Nothing> { throw error }.test {
       assertSame(error, awaitError())
     }
+  }
+
+  @Test fun terminalErrorAfterExpectMostRecentItemThrows() = runTest {
+    val error = RuntimeException("hi")
+    val throwBarrier = Job()
+    val message = assertFailsWith<AssertionError> {
+      flow {
+        emit("item!")
+        throwBarrier.join()
+        throw error
+      }.test {
+        expectMostRecentItem()
+        throwBarrier.complete()
+      }
+    }.message
+
+    assertEquals("""
+        |Unconsumed events found:
+        | - Error(RuntimeException)
+        """.trimMargin(), message)
   }
 
   @Test fun expectErrorButWasItemThrows() = runTest {


### PR DESCRIPTION
Referenced in discussion [here](https://github.com/cashapp/turbine/pull/140/files#r967251998). Here's the bug this fixes:

When `expectMostRecentItem` is used to receive an `Item` event, an enclosing `.test { ... }` will incorrectly ignore any following events and pass the test when it should not.