### PR TITLE
Centralize custom exception subtype for tests

### DIFF
--- a/src/commonTest/kotlin/app/cash/turbine/CustomRuntimeException.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/CustomRuntimeException.kt
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2020 Square, Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package app.cash.turbine
+
+/**
+ * This type prevents coroutines from breaking referential equality by
+ * reflectively creating new instances.
+ */
+internal class CustomRuntimeException(
+  message: String?,
+  override val cause: Throwable? = null,
+) : RuntimeException(message)

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
@@ -16,7 +16,6 @@
 package app.cash.turbine
 
 import kotlin.test.Test
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertFalse
@@ -44,8 +43,7 @@ import kotlinx.coroutines.yield
 
 class FlowTest {
   @Test fun exceptionsPropagate() = runTest {
-    // Use a custom subtype to prevent coroutines from breaking referential equality.
-    val expected = object : RuntimeException("hello") {}
+    val expected = CustomRuntimeException("hello")
 
     val actual = assertFailsWith<RuntimeException> {
       neverFlow().test {
@@ -306,16 +304,13 @@ class FlowTest {
   }
 
   @Test fun expectItemButWasErrorThrows() = runTest {
-    val error = object : RuntimeException("hi") { }
+    val error = CustomRuntimeException("hi")
     val actual = assertFailsWith<AssertionError> {
       flow<Unit> { throw error }.test {
         awaitItem()
       }
     }
-    assertContains(
-      listOf("Expected item but found Error(null)", "Expected item but found Error(undefined)"),
-      actual.message,
-    )
+    assertEquals("Expected item but found Error(CustomRuntimeException)", actual.message)
     assertSame(error, actual.cause)
   }
 
@@ -341,7 +336,7 @@ class FlowTest {
   }
 
   @Test fun expectError() = runTest {
-    val error = object : RuntimeException("hi") { }
+    val error = CustomRuntimeException("hi")
     flow<Nothing> { throw error }.test {
       assertSame(error, awaitError())
     }
@@ -383,7 +378,7 @@ class FlowTest {
   }
 
   @Test fun expectErrorEvent() = runTest {
-    val exception = object : RuntimeException("hi") { }
+    val exception = CustomRuntimeException("hi")
     flow<Nothing> { throw exception }.test {
       val event = awaitEvent()
       assertEquals(Event.Error(exception), event)
@@ -417,8 +412,7 @@ class FlowTest {
   }
 
   @Test fun exceptionsPropagateWhenExpectMostRecentItem() = runTest {
-    // Use a custom subtype to prevent coroutines from breaking referential equality.
-    val expected = object : RuntimeException("hello") {}
+    val expected = CustomRuntimeException("hello")
 
     val actual = assertFailsWith<RuntimeException> {
       flow {
@@ -509,7 +503,7 @@ class FlowTest {
   }
 
   @Test fun expectErrorOnErrorReceivedBeforeAllItemsWereSkipped() = runTest {
-    val error = object : RuntimeException("hi") { }
+    val error = CustomRuntimeException("hi")
     flow {
       emit(1)
       throw error

--- a/src/commonTest/kotlin/app/cash/turbine/TurbineTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/TurbineTest.kt
@@ -16,7 +16,6 @@
 package app.cash.turbine
 
 import kotlin.test.Test
-import kotlin.test.assertContains
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
 import kotlin.test.assertSame
@@ -32,8 +31,7 @@ import kotlinx.coroutines.test.runTest
 class TurbineTest {
   @Test
   fun exceptionsPropagateWhenExpectMostRecentItem() = runTest {
-    // Use a custom subtype to prevent coroutines from breaking referential equality.
-    val expected = object : RuntimeException("hello") {}
+    val expected = CustomRuntimeException("hello")
 
     val actual = assertFailsWith<RuntimeException> {
       val channel = Turbine<Int>()
@@ -118,7 +116,7 @@ class TurbineTest {
 
   @Test
   fun expectErrorOnErrorReceivedBeforeAllItemsWereSkipped() = runTest {
-    val error = object : RuntimeException("hello") {}
+    val error = CustomRuntimeException("hello")
     val channel = Turbine<Int>()
     channel.add(1)
     channel.close(error)
@@ -152,7 +150,7 @@ class TurbineTest {
 
   @Test
   fun expectErrorEvent() = runTest {
-    val exception = object : RuntimeException("hello") {}
+    val exception = CustomRuntimeException("hello")
     val channel = Turbine<Any>()
     channel.close(exception)
     val event = channel.awaitEvent()
@@ -179,16 +177,13 @@ class TurbineTest {
 
   @Test
   fun awaitItemButWasErrorThrows() = runTest {
-    val error = object : RuntimeException("hello") {}
+    val error = CustomRuntimeException("hello")
     val actual = assertFailsWith<AssertionError> {
       val channel = Turbine<Any>()
       channel.close(error)
       channel.awaitItem()
     }
-    assertContains(
-      listOf("Expected item but found Error(null)", "Expected item but found Error(undefined)"),
-      actual.message,
-    )
+    assertEquals("Expected item but found Error(CustomRuntimeException)", actual.message)
     assertSame(error, actual.cause)
   }
 
@@ -221,7 +216,7 @@ class TurbineTest {
 
   @Test
   fun awaitError() = runTest {
-    val error = object : RuntimeException("hello") { }
+    val error = CustomRuntimeException("hello")
     val channel = Turbine<Any>()
     channel.close(error)
     assertSame(error, channel.awaitError())
@@ -271,7 +266,7 @@ class TurbineTest {
 
   @Test
   fun takeItemButWasErrorThrows() = withTestScope {
-    val error = object : RuntimeException("hello") {}
+    val error = CustomRuntimeException("hello")
     val actual = assertFailsWith<AssertionError> {
       val channel = Turbine<Any>()
       // JS
@@ -280,10 +275,7 @@ class TurbineTest {
       }
       channel.takeItem()
     }
-    assertContains(
-      listOf("Expected item but found Error(null)", "Expected item but found Error(undefined)"),
-      actual.message,
-    )
+    assertEquals("Expected item but found Error(CustomRuntimeException)", actual.message)
     assertSame(error, actual.cause)
   }
 


### PR DESCRIPTION
This gives the type a simple name which correctly shows up in the test messages.