### PR TITLE
Copy Channel timeout tests into Flow and Flow-in-scope tests

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -16,14 +16,12 @@
 package app.cash.turbine
 
 import kotlin.time.Duration
-import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.cancelAndJoin
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.channels.ChannelResult
-import kotlinx.coroutines.coroutineScope
 
 internal const val debug = false
 

--- a/src/commonMain/kotlin/app/cash/turbine/coroutines.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/coroutines.kt
@@ -24,12 +24,16 @@ import kotlinx.coroutines.withContext
 
 private val DEFAULT_TIMEOUT: Duration = 1000.milliseconds
 
+internal fun checkTimeout(timeout: Duration) {
+  check(timeout.isPositive()) { "Turbine timeout must be greater than 0: $timeout" }
+}
+
 /**
  * Sets a timeout for all [Turbine] instances within this context. If this timeout is not set,
  * the default value is 1sec.
  */
 public suspend fun <T> withTurbineTimeout(timeout: Duration, block: suspend CoroutineScope.() -> T): T {
-  check(timeout > Duration.ZERO) { "Turbine timeout must be greater than 0." }
+  checkTimeout(timeout)
   return withContext(TurbineTimeoutElement(timeout)) {
     block()
   }

--- a/src/commonMain/kotlin/app/cash/turbine/flow.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/flow.kt
@@ -84,6 +84,11 @@ public suspend fun <T> Flow<T>.test(
  * [withTurbineTimeout].
  */
 public fun <T> Flow<T>.testIn(scope: CoroutineScope, timeout: Duration? = null): ReceiveTurbine<T> {
+  if (timeout != null) {
+    // Eager check to throw early rather than in a subsequent 'await' call.
+    checkTimeout(timeout)
+  }
+
   val turbine = collectTurbineIn(scope, timeout)
 
   scope.coroutineContext.job.invokeOnCompletion { exception ->

--- a/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
@@ -217,12 +217,12 @@ class ChannelTest {
   }
 
   @Test fun failsOnDefaultTimeout() = runTest {
-    val message = assertFailsWith<AssertionError> {
+    val actual = assertFailsWith<AssertionError> {
       coroutineScope {
         neverFlow().collectIntoChannel(this).awaitItem()
       }
-    }.message
-    assertEquals("No value produced in 1s", message)
+    }
+    assertEquals("No value produced in 1s", actual.message)
   }
 
   @Test fun awaitHonorsCoroutineContextTimeoutNoTimeout() = runTest {
@@ -238,31 +238,29 @@ class ChannelTest {
     }
   }
 
-  @Test fun negativeTurbineTimeoutThrows() = runTest {
-    val message = assertFailsWith<IllegalStateException> {
-      withTurbineTimeout((-10).milliseconds) {
-
-      }
-    }.message
-    assertEquals("Turbine timeout must be greater than 0.", message)
-  }
-
-  @Test fun zeroTurbineTimeoutThrows() = runTest {
-    val message = assertFailsWith<IllegalStateException> {
-      withTurbineTimeout(0.milliseconds) {
-
-      }
-    }.message
-    assertEquals("Turbine timeout must be greater than 0.", message)
-  }
-
   @Test fun awaitHonorsCoroutineContextTimeoutTimeout() = runTest {
-    val message = assertFailsWith<AssertionError> {
+    val actual = assertFailsWith<AssertionError> {
       withTurbineTimeout(10.milliseconds) {
         neverFlow().collectIntoChannel(this).awaitItem()
       }
-    }.message
-    assertEquals("No value produced in 10ms", message)
+    }
+    assertEquals("No value produced in 10ms", actual.message)
+  }
+
+  @Test fun negativeTurbineTimeoutThrows() = runTest {
+    val actual = assertFailsWith<IllegalStateException> {
+      withTurbineTimeout((-10).milliseconds) {
+      }
+    }
+    assertEquals("Turbine timeout must be greater than 0: -10ms", actual.message)
+  }
+
+  @Test fun zeroTurbineTimeoutThrows() = runTest {
+    val actual = assertFailsWith<IllegalStateException> {
+      withTurbineTimeout(0.milliseconds) {
+      }
+    }
+    assertEquals("Turbine timeout must be greater than 0: 0s", actual.message)
   }
 
   @Test fun takeItem() = withTestScope {


### PR DESCRIPTION
This ensures we have the same coverage on all three APIs. Adjust timeout check so that it gets thrown for Flow-in-scope when you would expect.