### PR TITLE
Run wall-clock timeout in GlobalScope

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,9 +1,9 @@
 buildscript {
   dependencies {
-    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.10'
+    classpath 'org.jetbrains.kotlin:kotlin-gradle-plugin:1.7.20'
     classpath 'com.diffplug.spotless:spotless-plugin-gradle:5.15.1'
     classpath 'com.vanniktech:gradle-maven-publish-plugin:0.14.2'
-    classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.7.10'
+    classpath 'org.jetbrains.dokka:dokka-gradle-plugin:1.7.20'
   }
 
   ext.versions = [

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
@@ -44,6 +44,8 @@ import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.flow.onCompletion
 import kotlinx.coroutines.flow.onStart
 import kotlinx.coroutines.launch
+import kotlinx.coroutines.test.advanceTimeBy
+import kotlinx.coroutines.test.runCurrent
 import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 import kotlinx.coroutines.yield
@@ -654,6 +656,32 @@ class FlowTest {
         skipItems(3)
       }.message
       assertEquals("Expected 3 items for two item channel but got 2 items and Complete", message)
+    }
+  }
+
+  @Test
+  fun virtualTimeCanBeControlled() = runTest {
+    flow {
+      delay(5000)
+      emit("1")
+      delay(5000)
+      emit("2")
+    }.test {
+      expectNoEvents()
+
+      advanceTimeBy(5000)
+      expectNoEvents()
+
+      runCurrent()
+      assertEquals("1", awaitItem())
+
+      advanceTimeBy(5000)
+      expectNoEvents()
+
+      runCurrent()
+      assertEquals("2", awaitItem())
+
+      awaitComplete()
     }
   }
 }


### PR DESCRIPTION
This ensures its use of the Default dispatcher does not affect the use of a TestScheduler and its fake time.

Closes #164.