### PR TITLE
Replace expectComplete with awaitComplete in KDoc

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/flow.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/flow.kt
@@ -39,7 +39,7 @@ import kotlinx.coroutines.test.UnconfinedTestDispatcher
  * flowOf("one", "two").test {
  *   assertEquals("one", expectItem())
  *   assertEquals("two", expectItem())
- *   expectComplete()
+ *   awaitComplete()
  * }
  * ```
  *
@@ -75,7 +75,7 @@ public suspend fun <T> Flow<T>.test(
  * val turbine = flowOf("one", "two").testIn(this)
  * assertEquals("one", turbine.expectItem())
  * assertEquals("two", turbine.expectItem())
- * turbine.expectComplete()
+ * turbine.awaitComplete()
  * ```
  *
  * Unlike [test] which automatically cancels the flow at the end of the lambda, the returned


### PR DESCRIPTION
Updates KDoc for `test` and `testIn` to replace deprecated `expectComplete` with `awaitComplete`