### PR TITLE
Handle completion and exception correctly in expectNoEvents

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/channel.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/channel.kt
@@ -69,8 +69,7 @@ public fun <T> ReceiveChannel<T>.expectMostRecentItem(name: String? = null): T {
  * @throws AssertionError if unconsumed events are found.
  */
 public fun <T> ReceiveChannel<T>.expectNoEvents(name: String? = null) {
-  val result = tryReceive()
-  if (!result.isFailure) result.unexpectedResult(name, "no events")
+  tryReceive().toEvent()?.let { unexpectedEvent(name, it, "no events") }
 }
 
 /**

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
@@ -151,6 +151,40 @@ class FlowTest {
     )
   }
 
+  @Test
+  fun expectNoEventsFailsOnException() = runTest {
+    val expected = RuntimeException()
+    val actual = assertFailsWith<AssertionError> {
+      flow<Nothing> {
+        throw expected
+      }.test {
+        expectNoEvents()
+      }
+    }
+    assertEquals(
+      """
+        |Expected no events but found Error(RuntimeException)
+      """.trimMargin(),
+      actual.message,
+    )
+    assertSame(expected, actual.cause)
+  }
+
+  @Test
+  fun expectNoEventsFailsOnCompletion() = runTest {
+    val actual = assertFailsWith<AssertionError> {
+      emptyFlow<Nothing>().test {
+        expectNoEvents()
+      }
+    }
+    assertEquals(
+      """
+        |Expected no events but found Complete
+      """.trimMargin(),
+      actual.message,
+    )
+  }
+
   @Test fun unconsumedCompleteThrows() = runTest {
     val actual = assertFailsWith<AssertionError> {
       emptyFlow<Nothing>().test { }


### PR DESCRIPTION
Fixes #205.