### PR TITLE
Only build `trunk`

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -2,9 +2,10 @@ name: build
 
 on:
   pull_request: {}
+  workflow_dispatch: {}
   push:
     branches:
-      - '**'
+      - 'trunk'
     tags-ignore:
       - '**'
 


### PR DESCRIPTION
Otherwise branch builds require an explicit workflow dispatch. PR builds still run. This reduces the duplicate CI builds in almost every instance.