### PR TITLE
Remove background thread test tasks

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -77,22 +77,6 @@ kotlin {
       target.compilations.test.defaultSourceSet.dependsOn(sourceSets.nonJvmTest)
     }
   }
-
-  // Add a test binary and execution for native targets which runs on a background thread.
-  targets.withType(org.jetbrains.kotlin.gradle.plugin.mpp.KotlinNativeTargetWithTests).all {
-    binaries {
-      test('background', [org.jetbrains.kotlin.gradle.plugin.mpp.NativeBuildType.DEBUG]) {
-        freeCompilerArgs += [
-          "-trw"
-        ]
-      }
-    }
-    testRuns {
-      background {
-        setExecutionSourceFrom(binaries.getByName("backgroundDebugTest"))
-      }
-    }
-  }
 }
 
 apply plugin: 'com.diffplug.spotless'


### PR DESCRIPTION
With the new memory model these are not needed anymore.