### PR TITLE
Fix assertComplete typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ Then it calls the validation block, passing in the read-only `ReceiveTurbine` in
 ```kotlin
 flowOf("one").test {
   assertEquals("one", awaitItem())
-  assertComplete()
+  awaitComplete()
 }
 ```
 


### PR DESCRIPTION
Seems like a typo, there is no API such as `assertComplete()`.