### PR TITLE
Introduce turbine { ... } API

### DIFF
--- a/src/commonTest/kotlin/app/cash/turbine/FlowInScopeTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowInScopeTest.kt
@@ -283,5 +283,4 @@ class FlowInScopeTest {
       "No value produced for inner in 3s",
     )
   }
-
 }


### PR DESCRIPTION
Supports another scenario for #165.