### PR TITLE
Rename `turbine` to `turbineScope`

### DIFF
--- a/api/Turbine.api
+++ b/api/Turbine.api
@@ -57,8 +57,8 @@ public final class app/cash/turbine/FlowKt {
 	public static synthetic fun test-C2H2yOE$default (Lkotlinx/coroutines/flow/Flow;Lkotlin/time/Duration;Ljava/lang/String;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun testIn-5_5nbZA (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;)Lapp/cash/turbine/ReceiveTurbine;
 	public static synthetic fun testIn-5_5nbZA$default (Lkotlinx/coroutines/flow/Flow;Lkotlinx/coroutines/CoroutineScope;Lkotlin/time/Duration;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/turbine/ReceiveTurbine;
-	public static final fun turbine-k1IrOU0 (Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static synthetic fun turbine-k1IrOU0$default (Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
+	public static final fun turbineScope-k1IrOU0 (Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static synthetic fun turbineScope-k1IrOU0$default (Lkotlin/time/Duration;Lkotlin/jvm/functions/Function2;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 }
 
 public abstract interface class app/cash/turbine/ReceiveTurbine {

--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -94,7 +94,6 @@ public operator fun <T> Turbine<T>.plusAssign(value: T) { add(value) }
  * [withTurbineTimeout].
  * @param name If non-null, name is added to any exceptions thrown to help identify which [Turbine] failed.
  */
-@Suppress("FunctionName") // Interface constructor pattern.
 public fun <T> Turbine(
   timeout: Duration? = null,
   name: String? = null,

--- a/src/commonMain/kotlin/app/cash/turbine/flow.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/flow.kt
@@ -55,6 +55,7 @@ internal class TurbineContextImpl(
 
   private val turbineElements = (turbineContext[TurbineRegistryElement] ?: EmptyCoroutineContext) +
     (turbineContext[TurbineTimeoutElement] ?: EmptyCoroutineContext)
+
   override fun <R> Flow<R>.testIn(
     scope: CoroutineScope,
     timeout: Duration?,
@@ -71,7 +72,7 @@ internal class TurbineContextImpl(
 /**
  * Run a validation block that catches and reports all unhandled exceptions in flows run by Turbine.
  */
-public suspend fun turbine(
+public suspend fun turbineScope(
   timeout: Duration? = null,
   validate: suspend TurbineContext.() -> Unit,
 ) {
@@ -137,7 +138,7 @@ public suspend fun <T> Flow<T>.test(
   name: String? = null,
   validate: suspend TurbineTestContext<T>.() -> Unit,
 ) {
-  turbine {
+  turbineScope {
     collectTurbineIn(this, null, name).apply {
       val testContext = TurbineTestContextImpl(this@apply, currentCoroutineContext())
       if (timeout != null) {
@@ -185,7 +186,7 @@ private fun <T> testInInternal(flow: Flow<T>, timeout: Duration?, scope: Corouti
     checkTimeout(timeout)
   }
   if (scope.coroutineContext[TurbineRegistryElement] == null) {
-    throw AssertionError("Turbine can only collect flows within a TurbineContext")
+    throw AssertionError("Turbine can only collect flows within a TurbineContext. Wrap with turbineScope { .. }")
   }
 
   val turbine = flow.collectTurbineIn(scope, timeout, name)

--- a/src/commonTest/kotlin/app/cash/turbine/FlowInScopeTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowInScopeTest.kt
@@ -254,7 +254,7 @@ class FlowInScopeTest {
     val expected = CustomThrowable("hi")
 
     val actual = assertFailsWith<AssertionError> {
-      turbine {
+      turbineScope {
         flow<Nothing> {
           throw expected
         }.testIn(backgroundScope, name = "inner failing")
@@ -290,7 +290,10 @@ class FlowInScopeTest {
     val actual = assertFailsWith<AssertionError> {
       emptyFlow<Nothing>().testIn(backgroundScope, name = "inner failing")
     }
-    assertEquals("Turbine can only collect flows within a TurbineContext", actual.message)
+    assertEquals(
+      "Turbine can only collect flows within a TurbineContext. Wrap with turbineScope { .. }",
+      actual.message,
+    )
   }
 }
 
@@ -299,7 +302,7 @@ private interface TurbineTestScope : TurbineContext {
 }
 
 private fun runTestTurbine(validate: suspend TurbineTestScope.() -> Unit) = runTest {
-  turbine {
+  turbineScope {
     val turbineTestScope = object : TurbineTestScope, TurbineContext by this {
       override val backgroundScope: CoroutineScope = this@runTest.backgroundScope
     }


### PR DESCRIPTION
Closes #243 