### PR TITLE
Update README with Kotlin-DSL compatible snippets

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ flowOf("one", "two").test {
 
 ## Download
 
-```groovy
+```kotlin
 repositories {
   mavenCentral()
 }

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  testImplementation 'app.cash.turbine:turbine:1.0.0'
+  testImplementation("app.cash.turbine:turbine:1.0.0")
 }
 ```
 
@@ -30,14 +30,14 @@ dependencies {
 <summary>Snapshots of the development version are available in Sonatype's snapshots repository.</summary>
 <p>
 
-```groovy
+```kotlin
 repositories {
   maven {
-    url 'https://oss.sonatype.org/content/repositories/snapshots/'
+    url = uri("https://oss.sonatype.org/content/repositories/snapshots/")
   }
 }
 dependencies {
-  testImplementation 'app.cash.turbine:turbine:1.1.0-SNAPSHOT'
+  testImplementation("app.cash.turbine:turbine:1.1.0-SNAPSHOT")
 }
 ```
 


### PR DESCRIPTION
These snippets are backwards-compatible with Groovy, but work out of the box with the Gradle Kotlin DSL :)