### PR TITLE
Add `**` to gradle-wrapper.yaml path

### DIFF
--- a/.github/workflows/gradle-wrapper.yaml
+++ b/.github/workflows/gradle-wrapper.yaml
@@ -5,7 +5,7 @@ on:
     paths:
     - 'gradlew'
     - 'gradlew.bat'
-    - 'gradle/wrapper/'
+    - 'gradle/wrapper/**'
 
 jobs:
   validate:


### PR DESCRIPTION
Without the wildcard, file changes in the `gradle/wrapper/` directory were not triggering the `gradle-wrapper` action, as seen in [#283](https://github.com/cashapp/turbine/pull/283/checks).