### PR TITLE
Added more details to the error message

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -141,7 +141,7 @@ internal class ChannelTurbine<T>(
   override fun asChannel(): Channel<T> = channel
 
   override fun add(item: T) {
-    if (!channel.trySend(item).isSuccess) throw IllegalStateException("Added when closed")
+    if (!channel.trySend(item).isSuccess) throw IllegalStateException("Attempt to add item to a closed Turbine${name?.let { " named $it" } ?: ""}.")
   }
 
   @OptIn(DelicateCoroutinesApi::class)


### PR DESCRIPTION
Including the name of the Turbine instance if it's not null, to clarify which instance failed.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
