### PR TITLE
Update channel tests

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/flow.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/flow.kt
@@ -222,7 +222,7 @@ private fun <T> Flow<T>.collectTurbineIn(scope: CoroutineScope, timeout: Duratio
   }
 }
 
-internal fun <T> Flow<T>.collectIntoChannel(scope: CoroutineScope): Channel<T> {
+private fun <T> Flow<T>.collectIntoChannel(scope: CoroutineScope): Channel<T> {
   val output = Channel<T>(UNLIMITED)
   val job = scope.launch(start = UNDISPATCHED) {
     try {

--- a/src/commonTest/kotlin/app/cash/turbine/testUtil.common.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/testUtil.common.kt
@@ -16,6 +16,9 @@
 package app.cash.turbine
 
 import kotlinx.coroutines.awaitCancellation
+import kotlinx.coroutines.channels.Channel
+import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.flow
 
@@ -33,3 +36,15 @@ expect fun assertCallSitePresentInStackTraceOnJvm(
   entryPoint: String,
   callSite: String,
 )
+
+fun <T> channelOf(vararg items: T, closeCause: Throwable? = null): ReceiveChannel<T> {
+  return Channel<T>(UNLIMITED).also { channel ->
+    for (item in items) {
+      channel.trySend(item).getOrThrow()
+    }
+    channel.close(closeCause)
+  }
+}
+
+fun emptyChannel(): ReceiveChannel<Nothing> = channelOf()
+fun neverChannel(): ReceiveChannel<Nothing> = Channel()

--- a/src/jvmTest/kotlin/app/cash/turbine/ChannelJvmTest.kt
+++ b/src/jvmTest/kotlin/app/cash/turbine/ChannelJvmTest.kt
@@ -2,7 +2,6 @@ package app.cash.turbine
 
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
-import kotlinx.coroutines.flow.emptyFlow
 import kotlinx.coroutines.test.runTest
 import org.junit.Test
 
@@ -10,7 +9,7 @@ class ChannelJvmTest {
   @Test
   fun takeItemSuspendingThrows() = runTest {
     val actual = assertFailsWith<IllegalStateException> {
-      emptyFlow<Unit>().collectIntoChannel(this).takeItem()
+      emptyChannel().takeItem()
     }
     assertEquals("Calling context is suspending; use a suspending method instead", actual.message)
   }


### PR DESCRIPTION
Do not use internal functions to create channels.

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
