### PR TITLE
Update channel tests - takeComplete()

### DIFF
--- a/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
@@ -261,6 +261,19 @@ class ChannelTest {
     assertEquals("Expected item but found Error(CustomThrowable)", actual.message)
     assertSame(error, actual.cause)
   }
+  
+  @Test fun takeComplete() = withTestScope {
+    val channel = channelOf("item!")
+    channel.takeItem()
+    channel.takeComplete()
+  }
+
+  @Test fun takeCompleteFailsForItem() = withTestScope {
+    val channel = channelOf("item!")
+    assertFailsWith<AssertionError> {
+      channel.takeComplete()
+    }
+  }
 
   @Test
   fun expectMostRecentItemButNoItemWasFoundThrowsWithName() = runTest {

--- a/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
@@ -261,7 +261,7 @@ class ChannelTest {
     assertEquals("Expected item but found Error(CustomThrowable)", actual.message)
     assertSame(error, actual.cause)
   }
-  
+
   @Test fun takeComplete() = withTestScope {
     val channel = channelOf("item!")
     channel.takeItem()


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
