### PR TITLE
Prepare version 1.2.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,23 @@
 # Change Log
 
 ## [Unreleased]
-[Unreleased]: https://github.com/cashapp/turbine/compare/1.1.0...HEAD
+[Unreleased]: https://github.com/cashapp/turbine/compare/1.2.0...HEAD
+
+### Added
+- Nothing yet!
+
+### Changed
+- Nothing yet!
+
+### Fixed
+- Nothing yet!
+
+
+## [1.2.0] - 2024-10-16
+[1.2.0]: https://github.com/cashapp/turbine/releases/tag/1.2.0
 
 ### Added
 - Add `wasmWasi` target.
-
-### Changed
-
-### Fixed
 
 
 ## [1.1.0] - 2024-03-06

--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ repositories {
   mavenCentral()
 }
 dependencies {
-  testImplementation("app.cash.turbine:turbine:1.1.0")
+  testImplementation("app.cash.turbine:turbine:1.2.0")
 }
 ```
 
@@ -37,7 +37,7 @@ repositories {
   }
 }
 dependencies {
-  testImplementation("app.cash.turbine:turbine:1.2.0-SNAPSHOT")
+  testImplementation("app.cash.turbine:turbine:1.3.0-SNAPSHOT")
 }
 ```
 

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ GROUP=app.cash.turbine
 POM_ARTIFACT_ID=turbine
 
 # HEY! If you change the major version here be sure to update release.yaml doc target folder!
-VERSION_NAME=1.2.0-SNAPSHOT
+VERSION_NAME=1.2.0
 
 SONATYPE_AUTOMATIC_RELEASE=true
 SONATYPE_HOST=DEFAULT

--- a/gradle.properties
+++ b/gradle.properties
@@ -2,7 +2,7 @@ GROUP=app.cash.turbine
 POM_ARTIFACT_ID=turbine
 
 # HEY! If you change the major version here be sure to update release.yaml doc target folder!
-VERSION_NAME=1.2.0
+VERSION_NAME=1.3.0-SNAPSHOT
 
 SONATYPE_AUTOMATIC_RELEASE=true
 SONATYPE_HOST=DEFAULT


### PR DESCRIPTION
---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
