### PR TITLE
Support CoroutineScope without a Job in testIn

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Nothing yet!
 
 ### Fixed
-- Nothing yet!
+- Calling `testIn` with a `CoroutineScope` that does not contain a `Job` no longer throws `IllegalStateException`.
 
 
 ## [1.2.0] - 2024-10-16

--- a/src/commonMain/kotlin/app/cash/turbine/flow.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/flow.kt
@@ -24,12 +24,12 @@ import kotlinx.coroutines.CoroutineScope
 import kotlinx.coroutines.CoroutineStart.UNDISPATCHED
 import kotlinx.coroutines.Dispatchers.Unconfined
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
-import kotlinx.coroutines.job
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -180,7 +180,7 @@ public fun <T> Flow<T>.testIn(
 
   val turbine = collectTurbineIn(scope, timeout, name)
 
-  scope.coroutineContext.job.invokeOnCompletion { exception ->
+  scope.coroutineContext[Job]?.invokeOnCompletion { exception ->
     if (debug) println("Scope ending ${exception ?: ""}")
 
     // Only validate events were consumed if the scope is exiting normally.


### PR DESCRIPTION
Most `CoroutineScope`s contain a `Job`, and should contain a `Job` to work with structured concurrency. However, some `CoroutineScope`s do not have a `Job` (`GlobalScope` is an example).

This change adds support for `CoroutineScope`s with no `Job` to Turbine's `testIn` function, which previously would throw `IllegalStateException` if called with such a `CoroutineScope`.

A `CoroutineScope` with no `Job` never completes, so a call to `invokeOnCompletion` is not needed in that case.

---

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
