### PR TITLE
Add of turbineOf method

### DIFF
--- a/README.md
+++ b/README.md
@@ -131,6 +131,36 @@ Otherwise, make sure to call one of the following methods before the end of your
 
 Otherwise, your test will hang.
 
+### Multiple Combined Flows
+
+If you need to test multiple flows together and assert the exact order in which their emissions
+occur, you can merge them into a single Turbine test. This is useful when validating coordinated
+behaviour across multiple streams. Use the `turbineOf`, which merges all provided flows
+and exposes their emissions through a single TurbineTestContext.
+
+```
+runTest {
+  turbineScope {
+  val flowA = flow {
+    emit("A1")
+    delay(50)
+    emit("A2")
+  }
+
+  val flowB = flow {
+    delay(25)
+    emit(1)
+  }
+
+  turbineOf(flowA, flowB) {
+    assertEquals("A1", awaitFor<String>())
+    assertEquals(1, awaitFor<Int>())
+    assertEquals("A2", awaitFor<String>())
+    awaitComplete()
+  }
+}
+```
+
 ### Consuming All Events
 
 Failing to consume all events before the end of a flow-based `Turbine`'s validation block will fail your test:

--- a/src/commonMain/kotlin/app/cash/turbine/channel.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/channel.kt
@@ -193,6 +193,22 @@ public suspend fun <T> ReceiveChannel<T>.awaitItem(name: String? = null): T =
   }
 
 /**
+ * Assert that the next event received is an item of type [T] and return it.
+ * This function suspends while waiting for the next event to arrive.
+ *
+ * Like [awaitItem], this will fail with an [AssertionError] if the next event is
+ * a completion signal or an error. The returned value is cast to the expected
+ * type [T], making it convenient when working with merged or heterogeneous flows
+ * where items may need to be asserted with stronger typing.
+ *
+ * @throws AssertionError if the next event was completion or an error.
+ * @throws ClassCastException if the emitted item cannot be cast to [T].
+ */
+public suspend inline fun <reified T> TurbineTestContext<*>.awaitFor(): T {
+  return awaitItem() as T
+}
+
+/**
  * Assert that [count] item events were received and ignore them.
  * This function will suspend if no events have been received.
  *

--- a/src/commonMain/kotlin/app/cash/turbine/flow.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/flow.kt
@@ -30,6 +30,7 @@ import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
 import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.currentCoroutineContext
 import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.merge
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.plus
 import kotlinx.coroutines.test.TestCoroutineScheduler
@@ -67,6 +68,31 @@ internal class TurbineContextImpl(
       name = name,
       scope = scope + turbineElements,
     )
+}
+
+/**
+ * Terminal test operator that merges the given [flows] and exposes all emitted events through a
+ * single Turbine, allowing the [validate] lambda to consume and assert them in strict
+ * emission order.
+ *
+ * The order in which items are observed inside [validate] matches exactly the order in which they
+ * are emitted from the merged flows.
+ *
+ * ```kotlin
+ * turbineOf(flowA, flowB) {
+ *   assertEquals("A1", awaitFor<String>())
+ *   assertEquals(1, awaitFor<Int>)
+ *   assertEquals("A2", awaitFor<String>)
+ * }
+ * ```
+ */
+public suspend fun <T> turbineOf(
+  vararg flows: Flow<T>,
+  timeout: Duration? = null,
+  name: String? = null,
+  validate: suspend TurbineTestContext<T>.() -> Unit,
+) {
+  merge(*flows).test(timeout, name, validate)
 }
 
 /**

--- a/src/commonTest/kotlin/app/cash/turbine/FlowInScopeTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowInScopeTest.kt
@@ -322,6 +322,28 @@ class FlowInScopeTest {
       actual.message,
     )
   }
+
+  @Test
+  fun turbineOfInterleavesTwoFlowsInStrictOrder() = runTest {
+    val flowA = flow {
+      emit("A1")
+      delay(50)
+      emit("A2")
+    }
+
+    val flowB = flow {
+      delay(25)
+      emit(1)
+    }
+
+    turbineOf(flowA, flowB) {
+      assertEquals("A1", awaitFor<String>())
+      assertEquals(1, awaitFor<Int>())
+      assertEquals("A2", awaitFor<String>())
+
+      awaitComplete()
+    }
+  }
 }
 
 private interface TurbineTestScope : TurbineContext {


### PR DESCRIPTION
Hi, I’m Gabriel. 

If possible, I would like to propose a function that has helped me validate the strict order of emissions across multiple flows.

While reading the documentation, I found the recommended way to test each flow individually:

```kotlin
turbineScope {
    val turbine1 = flowOf(1).testIn(backgroundScope)
    val turbine2 = flowOf(2).testIn(backgroundScope)
    assertEquals(1, turbine1.awaitItem())
    assertEquals(2, turbine2.awaitItem())
}
```

However, with this approach, if I need to validate the strict order of emissions across two flows, such as SharedFlow and StateFlow inside a ViewModel, I only have the option to check them separately.

The problem is that if the production code accidentally changes the order of events, the test still succeeds.

Example (production code):
```
	1.	flowA emits "A1"
	2.	flowB emits 1
	3.	flowA emits "A2"
```

Test:
```
	1.	await "A1" from flowA
	2.	await 1 from flowB
	3.	await "A2" from flowA
```

But if production code changes to:
```
	1.	flowA emits "A1"
	2.	flowA emits "A2"
	3.	flowB emits 1
```

The test continues to pass, even though the order is no longer correct.

With this MR, I would like to propose the turbineOf method, which merges multiple flows and allows validating the exact emission order. This function has been very helpful in my own projects, and I believe it would be useful for other developers as well.

Thank you in advance.