### PR TITLE
Add method awaitUntil(predicate: (item: T) -> Boolean): T

### DIFF
--- a/src/commonMain/kotlin/app/cash/turbine/ReceiveTurbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/ReceiveTurbine.kt
@@ -85,6 +85,18 @@ public interface ReceiveTurbine<T> {
   public suspend fun awaitItem(): T
 
   /**
+   * Assert that an event was an item that satisfies the [predicate] and return it.
+   * Previous items that did not satisfy the given [predicate] were ignored and skipped.
+   * This function will suspend if no events have been received.
+   *
+   * When this [ReceiveTurbine] is in a terminal state ([Event.Complete] or [Event.Error]), this
+   * method will yield the same result every time it is called.
+   *
+   * @throws AssertionError if one of the events was completion or an error.
+   */
+  public suspend fun awaitUntil(predicate: (item: T) -> Boolean): T
+
+  /**
    * Assert that [count] item events were received and ignore them. This function will suspend if no
    * events have been received.
    *

--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -211,6 +211,9 @@ internal class ChannelTurbine<T>(
   }
 
   override suspend fun awaitItem(): T = withTurbineTimeout { channel.awaitItem(name = name) }
+  override suspend fun awaitUntil(predicate: (item: T) -> Boolean): T = withTurbineTimeout {
+    channel.awaitUntil(name = name, predicate = predicate)
+  }
 
   override suspend fun skipItems(count: Int) = withTurbineTimeout { channel.skipItems(count, name) }
 

--- a/src/commonMain/kotlin/app/cash/turbine/channel.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/channel.kt
@@ -188,6 +188,43 @@ public suspend fun <T> ReceiveChannel<T>.awaitItem(name: String? = null): T =
   }
 
 /**
+ * Assert that an event was an item satisfies the [predicate] and return it.
+ * Previous items that did not satisfy the given [predicate] were ignored and skipped.
+ * This function will suspend if no events have been received.
+ *
+ * When this [ReceiveTurbine] is in a terminal state ([Event.Complete] or [Event.Error]), this
+ * method will yield the same result every time it is called.
+ *
+ * @throws AssertionError if one of the events was completion or an error.
+ */
+public suspend fun <T> ReceiveChannel<T>.awaitUntil(name: String? = null, predicate: (item: T) -> Boolean): T {
+  var event: Event<T>
+  var found: Boolean
+  do {
+    event = awaitEvent(name = name)
+    val item = (event as? Event.Item<T>)
+    found = item != null && predicate(item.value)
+  } while (!found && event !is Event.Complete && event !is Event.Error)
+  return when (event) {
+    Event.Complete,
+    is Event.Error -> {
+      val cause = (event as? Event.Error)?.throwable
+      throw TurbineAssertionError(
+        "No item satisfying the given predicate was found",
+        cause,
+      )
+    }
+    is Event.Item<T> -> {
+      if (found) {
+        event.value
+      } else {
+        unexpectedEvent(name, event, "item")
+      }
+    }
+  }
+}
+
+/**
  * Assert that [count] item events were received and ignore them. This function will suspend if no
  * events have been received.
  *

--- a/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
@@ -75,6 +75,37 @@ class ChannelTest {
   }
 
   @Test
+  fun awaitUntilFound() = runTest {
+    val channel = channelOf(1, 2, 3)
+    val item = channel.awaitUntil { it == 2 }
+    assertEquals(2, item)
+  }
+
+  @Test
+  fun awaitUntilMoreThanOneItemFound() = runTest {
+    val channel = channelOf(1, 2, 3, 1)
+    val item1 = channel.awaitUntil { it == 1 }
+    val item2 = channel.awaitUntil { it == 1 }
+    assertEquals(1, item1)
+    assertEquals(1, item2)
+  }
+
+  @Test
+  fun awaitUntilNotFound() = runTest {
+    val channel = channelOf(1, 2, 3)
+    val message = assertFailsWith<AssertionError> { channel.awaitUntil { it == 4 } }.message
+    assertEquals("No item satisfying the given predicate was found", message)
+  }
+
+  @Test
+  fun awaitUntilExpectErrorOnErrorReceived() = runTest {
+    val error = CustomThrowable("hello")
+    val channel = channelOf(1, closeCause = error)
+    val actual = assertFailsWith<AssertionError> { channel.awaitUntil { it == 2 } }
+    assertSame(error, actual.cause)
+  }
+
+  @Test
   fun awaitItemsAreSkipped() = runTest {
     val channel = channelOf(1, 2, 3)
     channel.skipItems(2)

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
@@ -566,6 +566,34 @@ class FlowTest {
   }
 
   @Test
+  fun awaitUntilItemFound() = runTest {
+    flowOf(1, 2, 3).test {
+      val item = awaitUntil { it == 3 }
+      assertEquals(3, item)
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun awaitUntilMoreThanOneItemFound() = runTest {
+    flowOf(1, 2, 3, 2).test {
+      val item1 = awaitUntil { it == 2 }
+      val item2 = awaitUntil { it == 2 }
+      assertEquals(2, item1)
+      assertEquals(2, item2)
+      awaitComplete()
+    }
+  }
+
+  @Test
+  fun awaitUntilThrowsWhenNotFound() = runTest {
+    flowOf(1, 2).test {
+      val message = assertFailsWith<AssertionError> { awaitUntil { it == 3 } }.message
+      assertEquals("No item satisfying the given predicate was found", message)
+    }
+  }
+
+  @Test
   fun expectItemsAreSkipped() = runTest {
     flowOf(1, 2, 3).test {
       skipItems(2)

--- a/src/commonTest/kotlin/app/cash/turbine/TurbineTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/TurbineTest.kt
@@ -96,6 +96,44 @@ class TurbineTest {
   }
 
   @Test
+  fun awaitUntilItemFound() = runTest {
+    val channel = Turbine<Int>()
+    listOf(1, 2, 3).forEach { channel.add(it) }
+
+    val item = channel.awaitUntil { it == 2 }
+    assertEquals(2, item)
+  }
+
+  @Test
+  fun awaitUntilMoreThanOneItemFound() = runTest {
+    val channel = Turbine<Int>()
+    listOf(1, 2, 3).forEach { channel.add(it) }
+
+    val item1 = channel.awaitUntil { it == 1 }
+    val item2 = channel.awaitUntil { it == 2 }
+    assertEquals(1, item1)
+    assertEquals(2, item2)
+  }
+
+  @Test
+  fun awaitUntilExpectErrorOnErrorReceived() = runTest {
+    val error = CustomThrowable("hello")
+    val channel = Turbine<Int>()
+    channel.add(1)
+    channel.close(error)
+    val actual = assertFailsWith<AssertionError> { channel.awaitUntil { it == 2 } }
+    assertSame(error, actual.cause)
+  }
+
+  @Test
+  fun awaitUntilExpectErrorOnCompletion() = runTest {
+    val channel = Turbine<Int>()
+    channel.add(1)
+    channel.close()
+    assertFailsWith<AssertionError> { channel.awaitUntil { it == 2 } }
+  }
+
+  @Test
   fun awaitItemsAreSkipped() = runTest {
     val channel = Turbine<Int>()
     listOf(1, 2, 3).forEach { channel.add(it) }


### PR DESCRIPTION
Add method awaitUntil(predicate: (item: T) -> Boolean): T

Sometimes you just want to await for a certain item to emit when testing a flow but you don't know how many items to skip in order to catch that item. 

```
flowOf(1, 2, 3).test {
  val item = awaitUntil { it == 3 }
  assertEquals(3, item)
  awaitComplete()
}
```
