### PR TITLE
Remove workaround for adding ABI task to check

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -13,11 +13,6 @@ kotlin {
 
   abiValidation {
     enabled = true
-
-    // TODO work around https://youtrack.jetbrains.com/issue/KT-78525
-    tasks.named('check') {
-      dependsOn(legacyDump.legacyCheckTaskProvider)
-    }
   }
 
   androidNativeArm32()


### PR DESCRIPTION
This is now done automatically in 2.3.20

    ❯ gw check --dry-run --console=plain | grep -i abi
    :internalDumpKotlinAbi SKIPPED
    :checkKotlinAbi SKIPPED

---

- [ ] `CHANGELOG.md`'s "Unreleased" section has been updated, if applicable.
