### PR TITLE
Fix expectNoEvents() failing after a consumed terminal event

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@
 - Nothing yet!
 
 ### Fixed
-- Nothing yet!
+- `expectNoEvents()` no longer fails when the flow's terminal event (completion or error) has already been consumed.
 
 
 ## [1.2.1] - 2025-06-11

--- a/src/commonMain/kotlin/app/cash/turbine/ReceiveTurbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/ReceiveTurbine.kt
@@ -51,6 +51,10 @@ public interface ReceiveTurbine<T> {
   /**
    * Assert that there are no unconsumed events which have already been received.
    *
+   * A terminal event (completion or error) that has already been consumed does not count as an
+   * unconsumed event, so this succeeds after the flow has terminated and its terminal event was
+   * awaited.
+   *
    * @throws AssertionError if unconsumed events are found.
    */
   public fun expectNoEvents()

--- a/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/Turbine.kt
@@ -115,7 +115,10 @@ internal class ChannelTurbine<T>(
       override fun tryReceive(): ChannelResult<T> {
         val result = channel.tryReceive()
         val event = result.toEvent()
-        if (event is Event.Error || event is Event.Complete) ignoreRemainingEvents = true
+        if (event is Event.Error || event is Event.Complete) {
+          ignoreRemainingEvents = true
+          terminalEventReceived = true
+        }
 
         return result
       }
@@ -132,6 +135,7 @@ internal class ChannelTurbine<T>(
         return channel.receiveCatching().also {
           if (it.toEvent()?.isTerminal == true) {
             ignoreRemainingEvents = true
+            terminalEventReceived = true
           }
         }
       }
@@ -181,6 +185,9 @@ internal class ChannelTurbine<T>(
   private var ignoreTerminalEvents = false
   private var ignoreRemainingEvents = false
 
+  /** True once a terminal event (complete or error) has been received off the channel. */
+  private var terminalEventReceived = false
+
   override suspend fun cancelAndIgnoreRemainingEvents() {
     cancel()
     ignoreRemainingEvents = true
@@ -201,6 +208,11 @@ internal class ChannelTurbine<T>(
   }
 
   override fun expectNoEvents() {
+    // A terminal event that has already been consumed is not an unconsumed event: the caller has
+    // already seen it. A closed channel re-surfaces its terminal event on every read, so reading it
+    // here would spuriously fail. Treat an already-consumed terminal as "no events".
+    // https://github.com/cashapp/turbine/issues/348
+    if (terminalEventReceived) return
     channel.expectNoEvents(name = name)
   }
 

--- a/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/FlowTest.kt
@@ -190,6 +190,27 @@ class FlowTest {
   }
 
   @Test
+  fun expectNoEventsAfterConsumedComplete() = runTest {
+    flowOf("one").test {
+      assertEquals("one", awaitItem())
+      awaitComplete()
+      // The terminal event has already been consumed, so there are no unconsumed events.
+      expectNoEvents()
+    }
+  }
+
+  @Test
+  fun expectNoEventsAfterConsumedError() = runTest {
+    val error = CustomThrowable("hi")
+    flow<Nothing> { throw error }
+      .test {
+        assertSame(error, awaitError())
+        // The terminal event has already been consumed, so there are no unconsumed events.
+        expectNoEvents()
+      }
+  }
+
+  @Test
   fun unconsumedCompleteThrows() = runTest {
     val actual = assertFailsWith<AssertionError> { emptyFlow<Nothing>().test {} }
     assertEquals(

--- a/src/commonTest/kotlin/app/cash/turbine/TurbineTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/TurbineTest.kt
@@ -125,6 +125,48 @@ class TurbineTest {
   @Test fun expectNoEvents() = runTest { Turbine<Any>().expectNoEvents() }
 
   @Test
+  fun expectNoEventsAfterConsumedComplete() = runTest {
+    val channel = Turbine<Int>()
+    channel.add(1)
+    channel.close()
+    assertEquals(1, channel.awaitItem())
+    channel.awaitComplete()
+    // The terminal event has already been consumed, so there are no unconsumed events.
+    channel.expectNoEvents()
+  }
+
+  @Test
+  fun expectNoEventsAfterConsumedError() = runTest {
+    val error = CustomThrowable("hello")
+    val channel = Turbine<Int>()
+    channel.close(error)
+    assertSame(error, channel.awaitError())
+    // The terminal event has already been consumed, so there are no unconsumed events.
+    channel.expectNoEvents()
+  }
+
+  @Test
+  fun expectNoEventsAfterTakenComplete() = withTestScope {
+    val channel = Turbine<Int>()
+    channel.add(1)
+    channel.close()
+    assertEquals(1, channel.takeItem())
+    channel.takeComplete()
+    // The terminal event has already been consumed, so there are no unconsumed events.
+    channel.expectNoEvents()
+  }
+
+  @Test
+  fun expectNoEventsAfterTakenError() = withTestScope {
+    val error = CustomThrowable("hello")
+    val channel = Turbine<Int>()
+    channel.close(error)
+    assertSame(error, channel.takeError())
+    // The terminal event has already been consumed, so there are no unconsumed events.
+    channel.expectNoEvents()
+  }
+
+  @Test
   fun awaitItemEvent() = runTest {
     val item = Any()
     val channel = Turbine<Any>()


### PR DESCRIPTION
Fixes the `expectNoEvents()` behaviour described in #348.

## Problem

A closed `Channel` re-yields its terminal event (`Complete`/`Error`) on every read, and `expectNoEvents()` reads the channel with no memory that the terminal was already consumed. So asserting "no more events" fails *after* you've already awaited completion:

```kotlin
flowOf("foo").test {
  skipItems(1)
  awaitComplete()
  expectNoEvents() // 💥 TurbineAssertionError: Expected no events but found Complete
}
```

## Fix

`ChannelTurbine` already tracks terminal consumption for its unconsumed-event reporting. This adds a dedicated `terminalEventReceived` flag, set wherever a terminal event is taken off the channel, and short-circuits `ChannelTurbine.expectNoEvents()` to succeed once a terminal has been consumed — an already-seen terminal is not an unconsumed event.

An **unconsumed** terminal still fails exactly as before (`expectNoEventsFailsOnCompletion` / `expectNoEventsFailsOnException` are unchanged and green), because the flag is only set after an `await*`/`take*` actually consumes the terminal.

**Scope:** this addresses only the `expectNoEvents()` half of #348. The issue also asks about restricting repeated `awaitComplete()` calls; per the maintainer note there, that behaviour is intentionally left as-is.

## Tests

Added regression tests (written first, confirmed failing before the fix) covering a consumed `Complete` and a consumed `Error`, for both the `Flow.test { }` path (`FlowTest`) and standalone `Turbine` (`TurbineTest`). The full `:jvmTest` suite passes.

No public API change — the `api/` ABI dumps are untouched.

- [x] `CHANGELOG.md`'s "Unreleased" section has been updated.
