### PR TITLE
Add ReceiveChannel.asReceiveTurbine

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@
 [Unreleased]: https://github.com/cashapp/turbine/compare/1.2.0...HEAD
 
 ### Added
-- Nothing yet!
+- Add `ReceiveChannel.asReceiveTurbine()` for adapting channels to the `ReceiveTurbine` API.
 
 ### Changed
 - Nothing yet!

--- a/api/Turbine.api
+++ b/api/Turbine.api
@@ -1,4 +1,6 @@
 public final class app/cash/turbine/ChannelKt {
+	public static final fun asReceiveTurbine (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/String;)Lapp/cash/turbine/ReceiveTurbine;
+	public static synthetic fun asReceiveTurbine$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/String;ILjava/lang/Object;)Lapp/cash/turbine/ReceiveTurbine;
 	public static final fun awaitComplete (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 	public static synthetic fun awaitComplete$default (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;ILjava/lang/Object;)Ljava/lang/Object;
 	public static final fun awaitError (Lkotlinx/coroutines/channels/ReceiveChannel;Ljava/lang/String;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;

--- a/api/Turbine.klib.api
+++ b/api/Turbine.klib.api
@@ -69,6 +69,7 @@ sealed interface <#A: out kotlin/Any?> app.cash.turbine/Event { // app.cash.turb
 }
 
 final fun <#A: kotlin/Any?> (app.cash.turbine/Turbine<#A>).app.cash.turbine/plusAssign(#A) // app.cash.turbine/plusAssign|plusAssign@app.cash.turbine.Turbine<0:0>(0:0){0§<kotlin.Any?>}[0]
+final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/ReceiveChannel<#A>).app.cash.turbine/asReceiveTurbine(kotlin/String? = ...): app.cash.turbine/ReceiveTurbine<#A> // app.cash.turbine/asReceiveTurbine|asReceiveTurbine@kotlinx.coroutines.channels.ReceiveChannel<0:0>(kotlin.String?){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/ReceiveChannel<#A>).app.cash.turbine/expectMostRecentItem(kotlin/String? = ...): #A // app.cash.turbine/expectMostRecentItem|expectMostRecentItem@kotlinx.coroutines.channels.ReceiveChannel<0:0>(kotlin.String?){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/ReceiveChannel<#A>).app.cash.turbine/expectNoEvents(kotlin/String? = ...) // app.cash.turbine/expectNoEvents|expectNoEvents@kotlinx.coroutines.channels.ReceiveChannel<0:0>(kotlin.String?){0§<kotlin.Any?>}[0]
 final fun <#A: kotlin/Any?> (kotlinx.coroutines.channels/ReceiveChannel<#A>).app.cash.turbine/takeComplete(kotlin/String? = ...) // app.cash.turbine/takeComplete|takeComplete@kotlinx.coroutines.channels.ReceiveChannel<0:0>(kotlin.String?){0§<kotlin.Any?>}[0]

--- a/src/commonMain/kotlin/app/cash/turbine/channel.kt
+++ b/src/commonMain/kotlin/app/cash/turbine/channel.kt
@@ -36,6 +36,83 @@ import kotlinx.coroutines.test.TestCoroutineScheduler
 import kotlinx.coroutines.withTimeout
 
 /**
+ * Adapts this channel to [ReceiveTurbine]; cancellation delegates to [ReceiveChannel.cancel]. It
+ * discards queued elements; consume-and-cancel returns only a pre-existing terminal event.
+ */
+public fun <T> ReceiveChannel<T>.asReceiveTurbine(name: String? = null): ReceiveTurbine<T> =
+  ReceiveChannelTurbine(this, name)
+
+private class ReceiveChannelTurbine<T>(
+  private val underlying: ReceiveChannel<T>,
+  private val name: String?,
+) : ReceiveTurbine<T> {
+  private val cancellation = CancellationException("ReceiveTurbine was cancelled")
+  private var ignoreRemainingEvents = false
+
+  private val events =
+    object : ReceiveChannel<T> by underlying {
+      override fun tryReceive(): ChannelResult<T> =
+        underlying.tryReceive().also(::recordTerminalEvent)
+
+      override suspend fun receiveCatching(): ChannelResult<T> =
+        underlying.receiveCatching().also(::recordTerminalEvent)
+    }
+
+  private fun recordTerminalEvent(result: ChannelResult<T>) {
+    if (result.toEvent()?.isTerminal == true) ignoreRemainingEvents = true
+  }
+
+  override fun asChannel(): ReceiveChannel<T> = underlying
+
+  override suspend fun cancel() = underlying.cancel(cancellation)
+
+  override suspend fun cancelAndIgnoreRemainingEvents() {
+    ignoreRemainingEvents = true
+    underlying.cancel(cancellation)
+  }
+
+  override suspend fun cancelAndConsumeRemainingEvents(): List<Event<T>> {
+    ignoreRemainingEvents = true
+    underlying.cancel(cancellation)
+    val terminal = underlying.takeEventUnsafe()
+    return listOfNotNull(terminal.takeUnless { it is Event.Error && it.throwable === cancellation })
+  }
+
+  override fun expectNoEvents() = events.expectNoEvents(name = name)
+
+  override fun expectMostRecentItem(): T = events.expectMostRecentItem(name = name)
+
+  override suspend fun awaitEvent(): Event<T> = events.awaitEvent(name = name)
+
+  override suspend fun awaitItem(): T = events.awaitItem(name = name)
+
+  override suspend fun skipItems(count: Int) = events.skipItems(count, name = name)
+
+  override suspend fun awaitComplete() = events.awaitComplete(name = name)
+
+  override suspend fun awaitError(): Throwable = events.awaitError(name = name)
+
+  override fun ensureAllEventsConsumed() {
+    if (ignoreRemainingEvents) return
+
+    val unconsumed = mutableListOf<Event<T>>()
+    var cause: Throwable? = null
+    while (true) {
+      val event = events.takeEventUnsafe() ?: break
+      if (event is Event.Error && event.throwable is CancellationException) break
+      unconsumed += event
+      if (event is Event.Error) cause = event.throwable
+      if (event.isTerminal) break
+    }
+
+    if (unconsumed.isNotEmpty()) {
+      val report = UnconsumedEventReport(name = name, unconsumed = unconsumed, cause = cause)
+      throw TurbineAssertionError(buildString { report.describe(this) }, cause)
+    }
+  }
+}
+
+/**
  * Returns the most recent item that has already been received. If channel was closed with no item
  * being received previously, this function will throw an [AssertionError]. If channel was closed
  * with an exception, this function will throw the underlying exception.

--- a/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
+++ b/src/commonTest/kotlin/app/cash/turbine/ChannelTest.kt
@@ -18,12 +18,17 @@ package app.cash.turbine
 import kotlin.test.Test
 import kotlin.test.assertEquals
 import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
 import kotlin.test.assertSame
+import kotlin.test.assertTrue
 import kotlin.time.Duration.Companion.milliseconds
+import kotlinx.coroutines.CancellationException
+import kotlinx.coroutines.CoroutineStart
 import kotlinx.coroutines.Dispatchers
 import kotlinx.coroutines.Job
 import kotlinx.coroutines.channels.Channel
 import kotlinx.coroutines.channels.Channel.Factory.UNLIMITED
+import kotlinx.coroutines.channels.ReceiveChannel
 import kotlinx.coroutines.delay
 import kotlinx.coroutines.launch
 import kotlinx.coroutines.test.TestScope
@@ -31,6 +36,146 @@ import kotlinx.coroutines.test.runTest
 import kotlinx.coroutines.withContext
 
 class ChannelTest {
+  @Test
+  fun receiveChannelAsReceiveTurbineDelegatesAndPreservesIdentity() = runTest {
+    val channel = channelOf(1)
+    var cancelled = false
+    val arbitraryChannel =
+      object : ReceiveChannel<Int> by channel {
+        override fun cancel(cause: CancellationException?) {
+          cancelled = true
+          channel.cancel(cause)
+        }
+      }
+    val turbine = arbitraryChannel.asReceiveTurbine()
+
+    assertSame(arbitraryChannel, turbine.asChannel())
+    assertEquals(1, turbine.awaitItem())
+    turbine.awaitComplete()
+    turbine.cancel()
+    assertTrue(cancelled)
+    turbine.ensureAllEventsConsumed()
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineIncludesNameInFailures() = runTest {
+    val expected = CustomThrowable("hello")
+    val turbine = channelOf<Nothing>(closeCause = expected).asReceiveTurbine(name = "error channel")
+
+    val actual = assertFailsWith<AssertionError> { turbine.awaitComplete() }
+
+    assertEquals(
+      "Expected complete for error channel but found Error(CustomThrowable)",
+      actual.message,
+    )
+    assertSame(expected, actual.cause)
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineRepeatsTerminalEvent() = runTest {
+    val expected = CustomThrowable("hello")
+    val turbine = channelOf<Nothing>(closeCause = expected).asReceiveTurbine()
+
+    assertSame(expected, turbine.awaitError())
+    assertSame(expected, turbine.awaitError())
+    turbine.ensureAllEventsConsumed()
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineReportsUnconsumedEvents() = runTest {
+    val turbine = channelOf("one", "two").asReceiveTurbine(name = "items")
+    assertEquals("one", turbine.awaitItem())
+
+    val actual = assertFailsWith<AssertionError> { turbine.ensureAllEventsConsumed() }
+
+    assertEquals(
+      """
+      |Unconsumed events found for items:
+      | - Item(two)
+      | - Complete
+      """
+        .trimMargin(),
+      actual.message,
+    )
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineCancelCancelsSuspendedRendezvousSender() = runTest {
+    val channel = Channel<Int>()
+    val turbine = channel.asReceiveTurbine()
+    val sender = launch(start = CoroutineStart.UNDISPATCHED) { channel.send(1) }
+    assertTrue(sender.isActive)
+
+    turbine.cancel()
+
+    sender.join()
+    assertTrue(sender.isCancelled)
+    assertFalse(channel.trySend(3).isSuccess)
+    val cancellation = turbine.awaitError()
+    assertTrue(cancellation is CancellationException)
+    assertSame(cancellation, turbine.awaitError())
+    turbine.ensureAllEventsConsumed()
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineConsumingCancelDoesNotChaseActiveProducer() = runTest {
+    val channel = Channel<Int>(capacity = 1)
+    val turbine = channel.asReceiveTurbine()
+    val producer =
+      launch(Dispatchers.Default, start = CoroutineStart.UNDISPATCHED) {
+        var item = 0
+        while (true) channel.send(item++)
+      }
+    assertTrue(producer.isActive)
+
+    val remaining = turbine.cancelAndConsumeRemainingEvents()
+
+    assertEquals(emptyList(), remaining)
+    producer.join()
+    assertTrue(producer.isCancelled)
+    turbine.ensureAllEventsConsumed()
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineRepeatedConcurrentCancelPreservesCloseCause() = runTest {
+    val expected = CustomThrowable("hello")
+    val channel = Channel<Int>(UNLIMITED)
+    channel.trySend(1).getOrThrow()
+    channel.close(expected)
+    val turbine = channel.asReceiveTurbine(name = "failed channel")
+
+    val cancellations = List(10) { launch(Dispatchers.Default) { repeat(10) { turbine.cancel() } } }
+    cancellations.forEach { it.join() }
+
+    val actual = assertFailsWith<AssertionError> { turbine.ensureAllEventsConsumed() }
+    assertEquals(
+      "Unconsumed events found for failed channel:\n - Error(CustomThrowable)",
+      actual.message,
+    )
+    assertSame(expected, actual.cause)
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineConsumingCancelReturnsPreexistingTerminalEvent() = runTest {
+    val expected = CancellationException("upstream cancellation")
+    val turbine = channelOf(1, 2, closeCause = expected).asReceiveTurbine()
+
+    val remaining = turbine.cancelAndConsumeRemainingEvents()
+
+    assertEquals(listOf(Event.Error(expected)), remaining)
+    assertSame(expected, (remaining.single() as? Event.Error)?.throwable)
+    turbine.ensureAllEventsConsumed()
+  }
+
+  @Test
+  fun receiveChannelAsReceiveTurbineCanIgnoreRemainingEvents() = runTest {
+    val turbine = channelOf(1, 2, closeCause = CustomThrowable("ignored")).asReceiveTurbine()
+
+    turbine.cancelAndIgnoreRemainingEvents()
+
+    turbine.ensureAllEventsConsumed()
+  }
+
   @Test
   fun exceptionsPropagateWhenExpectMostRecentItem() = runTest {
     val expected = CustomThrowable("hello")


### PR DESCRIPTION
## What does this PR do?

Adds the requested `ReceiveChannel.asReceiveTurbine(name)` convenience for using an existing receive channel through the `ReceiveTurbine` assertion API.

The adapter works with arbitrary `ReceiveChannel` implementations, preserves the original channel returned by `asChannel()`, forwards names and terminal causes, and cancels the original channel directly. Its cancellation behavior follows `ReceiveChannel.cancel()`, including discarding queued elements.

## Related issue

Closes #388

## How was this tested?

- Focused `ChannelTest` suite, including arbitrary-channel identity, naming and error causes, repeated terminals, unconsumed events, rendezvous senders, active producers, repeated concurrent cancellation, and pre-existing cancellation causes
- `./gradlew spotlessCheck`
- `./gradlew checkKotlinAbi`
- `./gradlew build dokkaGenerate -x tvosSimulatorArm64Test`
- `git diff --check`
